### PR TITLE
Avoid segfaulting when being passed a NULL retval by GDK

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,11 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPublicCall2(AMX *amx, const char *name,
 		}
 	}
 
-	*retval = result;
+	if (retval != NULL)
+	{
+		*retval = result;
+	}
+
 	return result;
 }
 


### PR DESCRIPTION
It is perfectly valid to get a NULL retval if the caller isn't
interested in the return value.

See the backtrace I've experienced:
```
#0  0xf668a10e in OnPublicCall2 (amx=0x84526f0, name=0x9cded00 "IRC_OnConnectAttempt", params=0xfff73418, retval=0x0, stop=0xfff733f6) at /home/cheaterman/samp/PySAMP/src/main.cpp:122
#1  0xf66920e8 in sampgdk_callback_invoke (amx=0x84526f0, name=0x9cded00 "IRC_OnConnectAttempt", paramcount=3, retval=0x0) at /home/cheaterman/samp/sampgdk/build/lib/sampgdk/sampgdk.c:2189
#2  0xf6692a30 in _sampgdk_amxhooks_Exec (amx=0x84526f0, retval=0x0, index=-10002) at /home/cheaterman/samp/sampgdk/build/lib/sampgdk/sampgdk.c:2459
```

Also see the GDK docs:

```
retval: Will hold the return value of the called function uponreturn. This parameter may be NULL if you are notinterested in the return value.
```