### PR TITLE
Automagically link sys.stdout to sampgdk::logprintf()

### DIFF
--- a/src/pysamp/pygamemode.cpp
+++ b/src/pysamp/pygamemode.cpp
@@ -31,6 +31,12 @@ PyGamemode::PyGamemode(const char * path)
 		sampgdk::logprintf("Setting python workspace failed.");
 
 	PyList_Append(sysPath, PyUnicode_FromString(absolute));
+
+	PyObject *module = PyImport_ImportModule("pysamp");
+	if(!module) {
+		PyErr_Print();
+		sampgdk::logprintf("Couldn't import module.");
+	}
 }
 
 PyGamemode::~PyGamemode()


### PR DESCRIPTION
This way, people can use print() in their scripts, and it goes in
server_log.txt (which is probably what they would expect).

This implements #62 :smile: I hope everyone loves it, it's probably going to be extremely convenient!