### PR TITLE
Fix the whole threading situation - see below for details.

### DIFF
--- a/gamemodes/empty/gamemode.py
+++ b/gamemodes/empty/gamemode.py
@@ -186,11 +186,3 @@ def OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, fX, fY, fZ):
 
 def OnProcessTick():
     return None
-
-""" you can initialize your own additional threads here, note that OnThreadingInit isn't supposed to be a worker thread but gives you the ability to start them. Otherwise it would block the plugin initialization """
-def OnThreadingInit():
-    return None
-
-""" your initialized threads must be shutdown during this callbac """
-def OnThreadingStopSignal():
-    return None

--- a/src/pysamp/pysamp.cpp
+++ b/src/pysamp/pysamp.cpp
@@ -7,12 +7,6 @@ void PySAMP::load()
 {
 	sampgdk::logprintf("Loading PySAMP gamemode");
 	PySAMP::gamemode = new PyGamemode(PYTHON_PATH);
-
-	if (!PyEval_ThreadsInitialized()) 
-	{
-		PyEval_InitThreads();
-	}
-
 	gamemode->load();
 }
 


### PR DESCRIPTION
I was personally getting deadlocks on exit, turns out the C++ thread was
stuck trying to acquire the GIL (which obviously was held by the main
thread - see https://docs.python.org/3/c-api/init.html#non-python-created-threads
for information on how this could actually have been done).
Our workaround? Let threads run during sampgdk::processtick() which
should not invoke any Python operation and can therefore safely release
the GIL.