### PR TITLE
Automagically define SAMP constants on pysamp module

### DIFF
--- a/src/bindings/samp.h
+++ b/src/bindings/samp.h
@@ -6599,7 +6599,6 @@ static PyMethodDef PySAMPMethods[] = {
 
 static PyModuleDef PySAMPModule = {
 	PyModuleDef_HEAD_INIT, "pysamp", "SAMP functions", -1, PySAMPMethods,
-	NULL, NULL, NULL, NULL
 };
 
 static PyMethodDef LogPrintfMethods[] = {

--- a/src/pysamp/pygamemode.cpp
+++ b/src/pysamp/pygamemode.cpp
@@ -34,8 +34,20 @@ PyGamemode::PyGamemode(const char * path)
 
 	PyObject *module = PyImport_ImportModule("pysamp");
 	if(!module) {
+		sampgdk::logprintf("Couldn't import module:");
 		PyErr_Print();
-		sampgdk::logprintf("Couldn't import module.");
+	}
+
+	for(auto item = SAMPConsts::map.begin(); item != SAMPConsts::map.end(); ++item) {
+		if(PyObject_SetAttrString(
+			module,
+			item->first.c_str,
+			Py_BuildValue("i", item->second)
+		) == -1) {
+			sampgdk::logprintf("Couldn't set constants on module:");
+			PyErr_Print();
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
This should make the Const() method essentially useless :smile: 

Example usage:

```python
from pysamp import INVALID_VEHICLE_ID
```