### PR TITLE
Properly line-buffer sys.std{out,err}.write() and properly flush() it

### DIFF
--- a/src/bindings/samp.h
+++ b/src/bindings/samp.h
@@ -1,6 +1,9 @@
 #ifndef samp_h
 #define samp_h
 #include <Python.h>
+#include <algorithm>
+#include <string>
+#include <sstream>
 #include <iostream>
 #include "sampgdk.h"
 #include "const.h"
@@ -6229,6 +6232,8 @@ static PyObject* pysamp_getvehiclemodelinfo(PyObject *self, PyObject *args)
 	return out;
 }
 
+extern std::string logprintf_buffer;
+
 static PyObject* logprintf_write(PyObject *self, PyObject *args)
 {
 	char *text;
@@ -6239,31 +6244,38 @@ static PyObject* logprintf_write(PyObject *self, PyObject *args)
 		return NULL;
 	}
 
-	unsigned int len_text = strlen(text);
+	std::stringstream text_stream(logprintf_buffer + text);
+	std::string line, text_stream_string = text_stream.str();
+	unsigned int num_lines = std::count(
+		text_stream_string.begin(),
+		text_stream_string.end(),
+		'\n'
+	), printed_len = 0;
 
-	if(
-		len_text == 0
-		|| (
-			len_text == 1
-			&& text[0] == '\n'
-		)
+	for(
+		unsigned int current_line = 0;
+		current_line < num_lines
+		&& std::getline(text_stream, line);
+		++current_line
 	)
 	{
-		// We will not print an empty line in the logs
-		PyMem_Free((void *)text);
-		return PyLong_FromUnsignedLong(0);
+		sampgdk::logprintf(line.c_str());
+		printed_len += line.length();
 	}
-	if(text[len_text - 1] == '\n')
-		// Truncate final newline
-		text[--len_text] = '\0';
 
-	sampgdk::logprintf(text);
+	std::getline(text_stream, logprintf_buffer);
+
 	PyMem_Free((void *)text);
-	return PyLong_FromUnsignedLong(len_text);
+	return PyLong_FromUnsignedLong(printed_len);
 }
 
 static PyObject* logprintf_flush(PyObject *self, PyObject *args)
 {
+	if(logprintf_buffer.length())
+	{
+		sampgdk::logprintf(logprintf_buffer.c_str());
+		logprintf_buffer.clear();
+	}
 	Py_RETURN_NONE;
 }
 
@@ -6667,7 +6679,7 @@ static PyModuleDef PySAMPModule = {
 
 static PyMethodDef LogPrintfMethods[] = {
 	{ "write", logprintf_write, METH_VARARGS, "Writes to server_log.txt - assigned to sys.std{out,err}.write at startup." },
-	{ "flush", logprintf_flush, METH_VARARGS, "Should flush server_log.txt writes - a no-op in practice (already done by default)." },
+	{ "flush", logprintf_flush, METH_VARARGS, "Flushes server_log.txt writes - empties internal line buffer into server_log.txt." },
 	{ NULL, NULL, 0, NULL },
 };
 

--- a/src/pysamp/pygamemode.cpp
+++ b/src/pysamp/pygamemode.cpp
@@ -1,5 +1,6 @@
 #include "pygamemode.h"
 
+std::string logprintf_buffer;
 
 //see http://stackoverflow.com/questions/8032080/how-to-convert-char-to-wchar-t
 const wchar_t *GetWC(const char *c)


### PR DESCRIPTION
Everything in the title :-)

Makes tracebacks that used to look like this:

```
[15:20:22] [cmds] [Cheaterman]: /crash
[15:20:22] Traceback (most recent call last):
[15:20:22]   File "/home/cheaterman/Dev/samp_server/python/gamemode/__init__.py", line 118, in OnPlayerCommandText
[15:20:22]     
[15:20:22] return handle_command(playerid, text)
[15:20:22]   File "/home/cheaterman/Dev/samp_server/python/gamemode/cmdparser.py", line 205, in handle_command
[15:20:22]     
[15:20:22] cmd.function(playerid, *prt[1:] if not cmd.raw else cmdtext)
[15:20:22]   File "/home/cheaterman/Dev/samp_server/python/gamemode/crasher.py", line 6, in crash
[15:20:22]     
[15:20:22] 1/0
[15:20:22] ZeroDivisionError
[15:20:22] : 
[15:20:22] division by zero
```

instead look like this:

```

[19:15:52] [cmds] [Cheaterman]: /crash
[19:15:52] Traceback (most recent call last):
[19:15:52]   File "/home/cheaterman/Dev/samp_server/python/gamemode/__init__.py", line 118, in OnPlayerCommandText
[19:15:52]     return handle_command(playerid, text)
[19:15:52]   File "/home/cheaterman/Dev/samp_server/python/gamemode/cmdparser.py", line 205, in handle_command
[19:15:52]     cmd.function(playerid, *prt[1:] if not cmd.raw else cmdtext)
[19:15:52]   File "/home/cheaterman/Dev/samp_server/python/gamemode/crasher.py", line 6, in crash
[19:15:52]     1/0
[19:15:52] ZeroDivisionError: division by zero
```