### PR TITLE
Add SetTimer/KillTimer - roughly same API as in Pawn...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,8 @@ add_samp_plugin(PySAMP
   pysamp/pysamp.h
   pysamp/pygamemode.cpp
   pysamp/pygamemode.h
+  pysamp/timer.cpp
+  pysamp/timer.h
   bindings/callbacks.h
   bindings/samp.h
   bindings/const.h

--- a/src/bindings/callbacks.h
+++ b/src/bindings/callbacks.h
@@ -4,8 +4,7 @@
 #include "sampgdk.h"
 #include "pysamp/pysamp.h"
 
-#include <stdio.h>
-#include <stdarg.h>
+#include <unordered_map>
 
 std::unordered_map<std::string, std::string> _createCallbackFormatMap()
 {

--- a/src/bindings/samp.h
+++ b/src/bindings/samp.h
@@ -6249,16 +6249,7 @@ Timer* timer_from_args(PyObject *args, PyObject *arguments)
 
 	if(!PyCallable_Check(function))
 	{
-		PyErr_SetString(PyExc_TypeError, "function must be callable");
-		return NULL;
-	}
-
-	if(
-		arguments != NULL
-		&& !PyTuple_Check(arguments)
-	)
-	{
-		PyErr_SetString(PyExc_TypeError, "arguments must be a tuple if present");
+		PyErr_SetString(PyExc_TypeError, "SetTimer() function must be callable");
 		return NULL;
 	}
 

--- a/src/bindings/samp.h
+++ b/src/bindings/samp.h
@@ -6249,7 +6249,7 @@ Timer* timer_from_args(PyObject *args, PyObject *arguments)
 
 	if(!PyCallable_Check(function))
 	{
-		PyErr_SetString(PyExc_TypeError, "SetTimer() function must be callable");
+		PyErr_SetString(PyExc_TypeError, "SetTimer() 'function' argument must be callable (pos 1)");
 		return NULL;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ PLUGIN_EXPORT void PLUGIN_CALL ProcessTick()
 {
 	if (PySAMP::isLoaded()) {
 		PySAMP::callback("OnProcessTick", NULL);
+		PySAMP::processTick((unsigned int)GetTickCount());
 	}
 	Py_BEGIN_ALLOW_THREADS
 	sampgdk::ProcessTick();

--- a/src/pysamp/pygamemode.cpp
+++ b/src/pysamp/pygamemode.cpp
@@ -1,4 +1,5 @@
 #include "pygamemode.h"
+#include "samp.h"
 
 std::string logprintf_buffer;
 
@@ -128,6 +129,9 @@ int PyGamemode::callback(const char * name, PyObject * pArgs, bool obtainLock)
 
 	if (obtainLock)
 		gstate = PyGILState_Ensure();
+
+	if (!PyObject_HasAttrString(pModule, name))
+		return ret;
 
 	PyObject* pFunc = PyObject_GetAttrString(pModule, name);
 

--- a/src/pysamp/pygamemode.h
+++ b/src/pysamp/pygamemode.h
@@ -4,7 +4,6 @@
 #include <Python.h>
 #include "sampgdk.h"
 #include <stdexcept>
-#include "samp.h"
 
 #ifdef DEBUG
 #define PY_DEBUG

--- a/src/pysamp/pysamp.cpp
+++ b/src/pysamp/pysamp.cpp
@@ -1,6 +1,7 @@
 #include "pysamp.h"
 
 PyGamemode* PySAMP::gamemode = nullptr;
+TimerManager* PySAMP::timer_manager = nullptr;
 
 
 void PySAMP::load()
@@ -8,19 +9,27 @@ void PySAMP::load()
 	sampgdk::logprintf("Loading PySAMP gamemode");
 	PySAMP::gamemode = new PyGamemode(PYTHON_PATH);
 	gamemode->load();
+	PySAMP::timer_manager = new TimerManager();
 }
 
 void PySAMP::reload()
 {
 	sampgdk::logprintf("Reloading PySAMP gamemode");
 	if (PySAMP::isLoaded())
+	{
 		PySAMP::gamemode->reload();
+		PySAMP::timer_manager->enable();
+		PySAMP::timer_manager->clear_timers();
+	}
 }
 
 void PySAMP::disable()
 {
 	if (PySAMP::isLoaded())
+	{
 		PySAMP::gamemode->disable();
+		PySAMP::timer_manager->disable();
+	}
 }
 
 void PySAMP::unload()
@@ -28,6 +37,8 @@ void PySAMP::unload()
 	sampgdk::logprintf("Unloading PySAMP gamemode");
 	delete PySAMP::gamemode;
 	PySAMP::gamemode = nullptr;
+	delete PySAMP::timer_manager;
+	PySAMP::timer_manager = nullptr;
 }
 
 int PySAMP::callback(const char * name, PyObject * pArgs)
@@ -55,4 +66,19 @@ bool PySAMP::isLoaded()
 bool PySAMP::isEnabled()
 {
 	return PySAMP::isLoaded() && PySAMP::gamemode->isEnabled();
+}
+
+void PySAMP::addTimer(Timer& timer)
+{
+	PySAMP::timer_manager->add_timer(timer);
+}
+
+void PySAMP::removeTimer(int id)
+{
+	PySAMP::timer_manager->remove_timer(id);
+}
+
+void PySAMP::processTick(unsigned int currentTick)
+{
+	PySAMP::timer_manager->process_timers(currentTick);
 }

--- a/src/pysamp/pysamp.h
+++ b/src/pysamp/pysamp.h
@@ -17,13 +17,16 @@
 
 
 #include "pygamemode.h"
+#include "timer.h"
 
 
+class PyGamemode;
 
 class PySAMP
 {
 private:
 	static PyGamemode* gamemode;
+	static TimerManager* timer_manager;
 public:
 	static void load();
 	static void reload();
@@ -34,6 +37,9 @@ public:
 	static bool isInitialized();
 	static bool isLoaded();
 	static bool isEnabled();
+	static void addTimer(Timer& timer);
+	static void removeTimer(int id);
+	static void processTick(unsigned int currentTick);
 };
 
 

--- a/src/pysamp/timer.cpp
+++ b/src/pysamp/timer.cpp
@@ -77,24 +77,16 @@ void TimerManager::process_timers(unsigned int current_tick)
 		int id = timer->get_id();
 		bool repeating = timer->is_repeating();
 
-		if(!timer->process(current_tick))
-		{
-			// Current timer wasn't processed
-			++timer;
-			continue;
-		}
-
 		if(
-			!repeating
+			timer->process(current_tick)
+			&& !repeating
 			&& _timer_exists(id)
 		)
 		{
-			// Current timer was processed and doesn't repeat
 			timer = timers.erase(timer);
 			continue;
 		}
 
-		// Current timer was processed and repeats, process next
 		++timer;
 	}
 }

--- a/src/pysamp/timer.cpp
+++ b/src/pysamp/timer.cpp
@@ -1,0 +1,107 @@
+#include "timer.h"
+
+
+int Timer::last_timer_id;
+
+Timer::Timer(
+	PyObject* function,
+	PyObject* arguments,
+	unsigned int interval,
+	bool repeating
+) :
+	function(function),
+	arguments(arguments),
+	interval(interval),
+	repeating(repeating)
+{
+	id = ++last_timer_id;
+	last_call_tick = GetTickCount();
+	Py_INCREF(function);
+	Py_XINCREF(arguments);
+}
+
+Timer::~Timer()
+{
+	Py_DECREF(function);
+	Py_XDECREF(arguments);
+}
+
+bool Timer::process(unsigned int current_tick)
+{
+	if((last_call_tick + interval) > current_tick)
+		return false;
+
+	last_call_tick = current_tick;
+	PyObject_CallObject(function, arguments);
+
+	if(PyErr_Occurred() != NULL)
+	{
+		PyErr_Print();
+		return false;
+	}
+
+	return true;
+}
+
+
+TimerManager::TimerManager()
+: disabled(false)
+{
+	Timer::last_timer_id = -1;
+}
+
+void TimerManager::add_timer(Timer& timer)
+{
+	timers.push_back(timer);
+}
+
+void TimerManager::remove_timer(int id)
+{
+	for(auto timer = timers.begin(); timer != timers.end(); ++timer)
+	{
+		if(timer->get_id() != id)
+			continue;
+
+		_remove_timer(timer);
+		break;
+	}
+}
+
+void TimerManager::process_timers(unsigned int current_tick)
+{
+	if(disabled)
+		return;
+
+	bool did_i_break;
+
+	do
+	{
+		did_i_break = false;
+
+		for(auto timer = timers.begin(); timer != timers.end(); ++timer)
+		{
+			bool repeating = timer->is_repeating();
+
+			if(!timer->process(current_tick))
+				continue;
+
+			if(!repeating)
+				_remove_timer(timer);
+
+			// XXX: Both process() and _remove_timer() could invalidate iterator
+			did_i_break = true;
+			break;
+		}
+	} while(did_i_break);
+}
+
+void TimerManager::clear_timers()
+{
+	for(auto timer = timers.begin(); timer != timers.end(); ++timer)
+		timer = _remove_timer(timer);
+}
+
+std::deque<Timer>::iterator TimerManager::_remove_timer(std::deque<Timer>::iterator timer)
+{
+	return timers.erase(timer);
+}

--- a/src/pysamp/timer.h
+++ b/src/pysamp/timer.h
@@ -1,0 +1,55 @@
+#ifndef PYTIMER_H
+#define PYTIMER_H
+
+#include <Python.h>
+#include <deque>
+
+#include "sampgdk.h"
+
+
+class Timer
+{
+public:
+	Timer(
+		PyObject* function,
+		PyObject* arguments,
+		unsigned int interval,
+		bool repeating
+	);
+	~Timer();
+	bool process(unsigned int current_tick);
+	int get_id() { return id; };
+	bool is_repeating() { return repeating; };
+
+	static int last_timer_id;
+
+private:
+	int id;
+	PyObject* function;
+	PyObject* arguments;
+	unsigned int interval;
+	bool repeating;
+	unsigned int last_call_tick;
+};
+
+
+class TimerManager
+{
+public:
+	TimerManager();
+	~TimerManager() {};
+	void add_timer(Timer& timer);
+	void remove_timer(int id);
+	void process_timers(unsigned int current_tick);
+	void clear_timers();
+	void enable() { disabled = false; };
+	void disable() { disabled = true; };
+
+private:
+	std::deque<Timer>::iterator _remove_timer(std::deque<Timer>::iterator timer);
+
+	std::deque<Timer> timers;
+	bool disabled;
+};
+
+#endif

--- a/src/pysamp/timer.h
+++ b/src/pysamp/timer.h
@@ -46,7 +46,7 @@ public:
 	void disable() { disabled = true; };
 
 private:
-	std::deque<Timer>::iterator _remove_timer(std::deque<Timer>::iterator timer);
+	bool _timer_exists(int id);
 
 	std::deque<Timer> timers;
 	bool disabled;


### PR DESCRIPTION
... except SetTimer takes function, interval, repeating, tuple_of_args as
arguments.

EDIT: Except it doesn't take tuple_of_args any longer, it takes variadic arguments.

Example:

```python
from pysamp import SetTimer, KillTimer
test_id = SetTimer(print, 1000, True, 'blibli')
SetTimer(KillTimer, 5000, False, test_id)
```
Will print "blibli" four times to the logs.