### PR TITLE
Fix segfault when several timers target the same function

### DIFF
--- a/src/pysamp/timer.cpp
+++ b/src/pysamp/timer.cpp
@@ -28,6 +28,26 @@ Timer::~Timer()
 	Py_XDECREF(arguments);
 }
 
+Timer& Timer::operator=(const Timer& timer)
+{
+	if(&timer == this)
+		return *this;
+
+	id = timer.id;
+	last_call_tick = timer.last_call_tick;
+	Py_DECREF(function);
+	Py_XDECREF(arguments);
+	function = timer.function;
+	arguments = timer.arguments;
+	Py_INCREF(function);
+	Py_XINCREF(arguments);
+	interval = timer.interval;
+	repeating = timer.repeating;
+	pending_deletion = timer.pending_deletion;
+
+	return *this;
+}
+
 Timer* Timer::from_args(PyObject *args, PyObject *arguments)
 {
 	PyObject* function;

--- a/src/pysamp/timer.h
+++ b/src/pysamp/timer.h
@@ -17,22 +17,7 @@ public:
 		bool repeating
 	);
 	~Timer();
-
-	Timer& operator=(const Timer& timer)
-	{
-		if(&timer == this)
-			return *this;
-
-		id = timer.id;
-		last_call_tick = timer.last_call_tick;
-		function = timer.function;
-		arguments = timer.arguments;
-		interval = timer.interval;
-		repeating = timer.repeating;
-		pending_deletion = timer.pending_deletion;
-
-		return *this;
-	}
+	Timer& operator=(const Timer& timer);
 
 	static Timer* from_args(PyObject *args, PyObject *arguments);
 	bool process(unsigned int current_tick);


### PR DESCRIPTION
Test case:
```python
def OnGameModeInit():
    import samp

    def printit(text):
        print(text)
        import gc
        gc.collect()

    samp.SetTimer(printit, 0, True, 'Timer 1')
    samp.SetTimer(printit, 0, False, 'Timer 2')
    samp.SetTimer(printit, 0, False, 'Timer 3')
```