### PR TITLE
Remove extra Pickup init arguments

### DIFF
--- a/pysamp/pickup.py
+++ b/pysamp/pickup.py
@@ -7,7 +7,7 @@ from pysamp import (
 class Pickup:
     """Pickups are global items that can be "picked" up by a player.
 
-    Pickups trigger an event `TODO: PLACEHOLDER` when picked up.
+    Pickups triggers :meth:`~pysamp.Player.on_pick_up_pickup` when picked up.
 
     Benefit of having pickups compared to static pickups, is that you can
     recreate, destroy and modify pickups, while static pickups can only be
@@ -17,28 +17,10 @@ class Pickup:
     def __init__(
         self,
         id: int,
-        model: int,
-        type: int,
-        x: float,
-        y: float,
-        z: float,
-        world: int,
     ) -> None:
 
         self.id = id
         """The pickup ID (readonly int)."""
-        self.model = model
-        """The model the pickup is using (readonly int)."""
-        self.type = type
-        """The type of the pickup (readonly int)."""
-        self.x = x
-        """The pickup X postition (readonly float)."""
-        self.y = y
-        """The pickup Y postition (readonly float)."""
-        self.z = z
-        """The pickup Z postition (readonly float)."""
-        self.world = world
-        """The virtual world the pickup exist in (readonly int)."""
 
     @classmethod
     def create(
@@ -74,13 +56,7 @@ class Pickup:
             give the player the weapon and some ammo.
         """
         return cls(
-            create_pickup(model, type, x, y, z, virtual_world),
-            model,
-            type,
-            x,
-            y,
-            z,
-            virtual_world,
+            create_pickup(model, type, x, y, z, virtual_world)
         )
 
     def destroy(self) -> bool:


### PR DESCRIPTION
As discussed on discord, this class should be same as other classes. Hence, removing extra arguments so that pickup events do not fail.