### PR TITLE
Some fixes and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ public OnPlayerConnect(playerid)
   new name[MAX_PLAYER_NAME], string[MAX_PLAYER_NAME + 24];
   GetPlayerName(playerid, name, MAX_PLAYER_NAME);
   format(string, sizeof(string), "%s has joined the server.", name);
-  SendClientMessageToAll(0x000000FF, string);
+  SendClientMessageToAll(0xFFFFFFFF, string);
 }
 ```
 
@@ -23,11 +23,11 @@ from pysamp import (
 @Player.on_connect
 def when_player_connects(player: Player):
     name = player.get_name()
-    send_client_message_to_all(0x000000FF,  f'{name} has joined the server.')
+    send_client_message_to_all(0xFFFFFFFF,  f'{name} has joined the server.')
 ```
- 
+
 As you can see, all referenced return values are removed and instead the method returns either a value or a tuple.
-The corresponding python gamemode has to be saved as `python.py` module or a `python/` package of your server directory. For a more complete python gamemode example, please check `/docker/server/empty.py`.
+The corresponding python gamemode has to be saved as `python.py` module or a `python/` package of your server directory. For a more complete python gamemode example, please check `/gamemodes/grandlarc/`.
 
 
 # Getting Started
@@ -93,7 +93,7 @@ With our docker setup, you can run your entire SA-MP server inside a docker cont
   3. Copy `/docker/server/empty.py` to your server root directory, renamed as `python.py`
   4. Copy `pysamp` folder/module to your server root directory.
   5. Run the server and verify that the plugin has loaded in your logs. If not, make sure step 1-4. is done correctly. You need exact versions of python.
-  
+
   <hr>
 </details>
 

--- a/pysamp/__init__.py
+++ b/pysamp/__init__.py
@@ -31,6 +31,7 @@ from samp import (
     BanEx,
     BlockIpAddress,
     CallNativeFunction,
+    CallRemoteFunction,
     RegisterCallback,
     CancelEdit,
     CancelSelectTextDraw,
@@ -2731,6 +2732,10 @@ def kill_timer(timer_id: int) -> None:
 
 def call_native_function(name: str, *arguments):
     return CallNativeFunction(name, *arguments)
+
+
+def call_remote_function(name: str, *arguments):
+    return CallRemoteFunction(name, *arguments)
 
 
 def register_callback(name: str, arguments: str):

--- a/pysamp/player.py
+++ b/pysamp/player.py
@@ -631,7 +631,8 @@ class Player:
             :up_down: Up/Down state
             :left_right: left/right state
 
-        See all keys here: https://sampwiki.blast.hk/wiki/Keys
+        See all keys here:
+        https://www.open.mp/docs/scripting/resources/keys
 
         .. note:: Only the FUNCTION of keys can be detected; not the actual
             keys.
@@ -940,7 +941,7 @@ class Player:
         ammunition interior.
 
         Learn more here:
-        https://sampwiki.blast.hk/wiki/ShopNames
+        https://www.open.mp/docs/scripting/resources/shopnames
         """
         return set_player_shop_name(self.id, shop_name)
 
@@ -992,7 +993,7 @@ class Player:
             surfed.
         """
         veh_id = get_player_surfing_vehicle_id(self.id)
-        if(veh_id == INVALID_VEHICLE_ID):
+        if (veh_id == INVALID_VEHICLE_ID):
             return None
         return Vehicle(veh_id)
 
@@ -1003,7 +1004,7 @@ class Player:
             standing on, or ``None`` if there's no moving object found.
         """
         obj_id = get_player_surfing_object_id(self.id)
-        if(obj_id == INVALID_OBJECT_ID):
+        if (obj_id == INVALID_OBJECT_ID):
             return None
         return Object(obj_id)
 
@@ -1281,7 +1282,7 @@ class Player:
             ``on_player_edit_attached_object`` to abort the edit.
         """
         return edit_attached_object(self.id, index)
-    
+
     def cancel_edit(self):
         """Cancel object edition mode for a player"""
         return cancel_edit(self.id)
@@ -1522,7 +1523,7 @@ class Player:
             and to play it no matter where the player is at.
 
         A list with available sound id's can be found here:
-        https://sampwiki.blast.hk/wiki/SoundID
+        https://www.open.mp/docs/scripting/resources/sound-ids
         """
         return player_play_sound(self.id, soundid, x, y, z)
 

--- a/pysamp/playertextdraw.py
+++ b/pysamp/playertextdraw.py
@@ -225,7 +225,8 @@ class PlayerTextDraw:
         :param int font: A font ID to give the textdraw (0-3).
         :return: No value is returned.
 
-        See all fonts here: https://sampwiki.blast.hk/wiki/PlayerTextDrawFont
+        See all fonts here:
+        https://www.open.mp/docs/scripting/functions/PlayerTextDrawFont
 
         .. warning:: Setting the ``font`` above 3 may crash the client.
         """

--- a/pysamp/textdraw.py
+++ b/pysamp/textdraw.py
@@ -221,7 +221,8 @@ class TextDraw:
         :param int font: A font ID to give the textdraw (0-3).
         :return: No value is returned.
 
-        See all fonts here: https://sampwiki.blast.hk/wiki/TextDrawFont
+        See all fonts here:
+        https://www.open.mp/docs/scripting/functions/TextDrawFont
 
         .. warning:: Setting the ``font`` above 3 may crash the client.
         """
@@ -347,7 +348,7 @@ class TextDraw:
         """Cancel textdraw selection with the mouse.
 
         :param Player player: The player that should be the textdraw selection disabled.
-        :return: This method does not return anything. 
+        :return: This method does not return anything.
         """
         return cancel_select_text_draw(player.id)
 

--- a/samp/__init__.pyi
+++ b/samp/__init__.pyi
@@ -2031,6 +2031,9 @@ def KillTimer(timer_id: int) -> None:
 def CallNativeFunction(name: str, *arguments) -> Any:
     pass
 
+def CallRemoteFunction(name: str, *arguments) -> Any:
+    pass
+
 def RegisterCallback(name: str, parameter_types: str) -> Any:
     pass
 


### PR DESCRIPTION
- Fixed `README.md` 0x000000FF ->0xFFFFFFFF (black color to white)
- All links to SA:MP documentation now point to the open.mp documentation, not the blast.hk archive.
- Added missing `call_remote_function()`.
- Fixed E275 (missing whitespace after keyword) in `pysamp.player`